### PR TITLE
WIP: ppx

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -51,6 +51,21 @@ Library "sqlexpr_syntax"
   XMETAType:        syntax
   XMETARequires:    camlp4, estring
 
+Library "ppx"
+  Path:             src/ppx/
+  FindlibName:      ppx
+  FindlibParent:    sqlexpr
+  XMETADescription: PPX extension for SQL statements/expressions
+  XMETARequires:    sqlexpr
+  XMETAExtraLines:  ppx = "ppx_sqlexpr"
+
+Executable "ppx_sqlexpr"
+  Path:             src/ppx/
+  MainIs:           ppx_sqlexpr.ml
+  BuildDepends:     unix, re.pcre, compiler-libs.common, ppx_tools.metaquot
+  CompiledObject:   best
+  Install:          true
+
 Executable "example"
   Path:             tests/
   MainIs:           example.ml

--- a/_tags
+++ b/_tags
@@ -2,7 +2,7 @@
 <tests/*>: syntax_camlp4o, package(sqlexpr.syntax), package(sqlexpr), thread
 
 # OASIS_START
-# DO NOT EDIT (digest: 52e395909f3ee097352522e19988a462)
+# DO NOT EDIT (digest: 8c33eb34542ae662c8d9b52b2978ec0d)
 # Ignore VCS directories, you can use the same kind of rule outside
 # OASIS_START/STOP if you want to exclude directories that contains
 # useless stuff for the build process
@@ -32,6 +32,17 @@ true: annot, bin_annot
 <src/syntax/*.ml{,i,y}>: pkg_camlp4.lib
 <src/syntax/*.ml{,i,y}>: pkg_camlp4.quotations.r
 <src/syntax/*.ml{,i,y}>: pkg_estring
+# Library ppx
+"src/ppx/ppx.cmxs": use_ppx
+# Executable ppx_sqlexpr
+<src/ppx/ppx_sqlexpr.{native,byte}>: pkg_compiler-libs.common
+<src/ppx/ppx_sqlexpr.{native,byte}>: pkg_ppx_tools.metaquot
+<src/ppx/ppx_sqlexpr.{native,byte}>: pkg_re.pcre
+<src/ppx/ppx_sqlexpr.{native,byte}>: pkg_unix
+<src/ppx/*.ml{,i,y}>: pkg_compiler-libs.common
+<src/ppx/*.ml{,i,y}>: pkg_ppx_tools.metaquot
+<src/ppx/*.ml{,i,y}>: pkg_re.pcre
+<src/ppx/*.ml{,i,y}>: pkg_unix
 # Executable example
 <tests/example.{native,byte}>: pkg_camlp4.lib
 <tests/example.{native,byte}>: pkg_camlp4.quotations.r

--- a/src/ppx/ppx_sqlexpr.ml
+++ b/src/ppx/ppx_sqlexpr.ml
@@ -1,0 +1,147 @@
+open Ast_helper
+open Asttypes
+open Parsetree
+
+module AC = Ast_convenience
+
+let new_id =
+  let n = ref 0 in
+  fun () ->
+    incr n;
+    Printf.sprintf "__ppx_sql_%d" !n
+
+let gen_stmt ~cacheable sql inp =
+  let mkapply fn args = AC.app (AC.evar fn) args in
+
+  let k = new_id () in
+  let st = new_id () in
+  let id =
+    let signature =
+      Printf.sprintf "%d-%f-%d-%S"
+        Unix.(getpid ()) (Unix.gettimeofday ()) (Random.int 0x3FFFFFF) sql
+    in Digest.to_hex (Digest.string signature) in
+  let stmt_id =
+    if cacheable
+    then [%expr Some [%e AC.str id ]]
+    else [%expr None] in
+  let exp = List.fold_right (fun elem dir ->
+    let typ = Sqlexpr_parser.in_type2str elem in
+    [%expr [%e mkapply typ [dir]]])
+    inp
+    [%expr [%e AC.evar k]] in
+    let dir = [%expr fun [%p AC.pvar k] -> fun [%p AC.pvar st] ->
+      let open Sqlexpr.Directives in [%e exp] [%e AC.evar st]
+    ] in
+  [%expr {
+    Sqlexpr.sql_statement = [%e AC.str sql];
+    stmt_id = [%e stmt_id];
+    directive = [%e dir];
+  }]
+
+let gen_expr ~cacheable sql inp outp =
+  let stmt = gen_stmt ~cacheable sql inp in
+  let id = new_id () in
+  let conv s = Longident.(Ldot (Ldot (Lident "Sqlexpr", "Conversion"), s)) in
+  let conv_exprs = List.mapi (fun i elem ->
+    let txt = conv (Sqlexpr_parser.out_type2str elem) in
+    let fn = Exp.ident {txt; loc=(!default_loc)} in
+    let args = [%expr Array.get [%e AC.evar id] [%e AC.int i]] in
+    AC.app fn [args]) outp in
+  let tuple_func =
+    let e = match conv_exprs with
+        [] -> assert false
+      | [x] -> x
+      | hd::tl -> Exp.tuple conv_exprs in
+    [%expr fun [%p AC.pvar id] -> [%e e]] in
+  [%expr {
+    Sqlexpr.statement = [%e stmt];
+    get_data = ([%e AC.int (List.length outp)], [%e tuple_func]);
+  }]
+
+let stmts = ref []
+let init_stmts = ref []
+
+let gen_sql ?(init=false) ?(cacheable=false) str =
+  let (sql, inp, outp) = Sqlexpr_parser.parse str in
+
+  (* accumulate statements *)
+  if init
+  then init_stmts := sql :: !init_stmts
+  else stmts := sql :: !stmts;
+
+  if [] = outp
+  then gen_stmt ~cacheable sql inp
+  else gen_expr ~cacheable sql inp outp
+
+let sqlcheck_sqlite () =
+  let mkstr s = Exp.constant (Const_string (s, None)) in
+  let statement_check = [%expr
+    try ignore(Sqlite3.prepare db stmt)
+    with Sqlite3.Error s ->
+      ret := false;
+      Format.fprintf fmt "Error in statement %S: %s\n" stmt s
+  ] in
+  let stmt_expr_f acc elem = [%expr [%e mkstr elem] :: [%e acc]] in
+  let stmt_exprs = List.fold_left stmt_expr_f [%expr []] !stmts in
+  let init_exprs = List.fold_left stmt_expr_f [%expr []] !init_stmts in
+  let check_db_expr = [%expr fun db fmt ->
+    let ret = ref true in
+    List.iter (fun stmt -> [%e statement_check]) [%e stmt_exprs];
+    !ret
+  ] in
+  let init_db_expr = [%expr fun db fmt ->
+    let ret = ref true in
+    List.iter (fun stmt -> match Sqlite3.exec db stmt with
+      | Sqlite3.Rc.OK -> ()
+      | rc -> begin
+        ret := false;
+        Format.fprintf fmt "Error in init. SQL statement (%s)@ %S@\n"
+          (Sqlite3.errmsg db) stmt
+      end) [%e init_exprs];
+      !ret
+  ] in
+  let in_mem_check_expr = [%expr fun fmt ->
+    let db = Sqlite3.db_open ":memory:" in
+    init_db db fmt && check_db db fmt
+  ] in
+  [%expr
+    let init_db = [%e init_db_expr] in
+    let check_db = [%e check_db_expr] in
+    let in_mem_check = [%e in_mem_check_expr] in
+    (init_db, check_db, in_mem_check)
+  ]
+
+let call fn loc = function
+  | PStr [ {pstr_desc = Pstr_eval (
+    { pexp_desc = Pexp_constant(Const_string(sym, _))}, _)} ] ->
+      with_default_loc loc (fun () -> fn sym)
+  | _ -> raise (Location.Error(Location.error ~loc (
+    "sqlexpr extension accepts a string")))
+
+let call_sqlcheck loc = function
+  | PStr [ {pstr_desc = Pstr_eval ({ pexp_desc =
+    Pexp_constant(Const_string("sqlite", None))}, _)}] ->
+      with_default_loc loc sqlcheck_sqlite
+  | _ -> raise (Location.Error(Location.error ~loc (
+    "sqlcheck extension accepts \"sqlite\"")))
+
+let new_mapper argv = Ast_mapper.({
+  default_mapper with
+  expr = fun mapper expr ->
+    match expr with
+    (* is this an extension node? *)
+    | {pexp_desc = Pexp_extension ({txt = "sql"; loc}, pstr)} ->
+        call gen_sql loc pstr
+    | {pexp_desc = Pexp_extension ({txt = "sqlc"; loc}, pstr)} ->
+        call (gen_sql ~cacheable:true) loc pstr
+    | {pexp_desc = Pexp_extension ({txt = "sqlinit"; loc}, pstr)} ->
+        call (gen_sql ~init:true) loc pstr
+    | {pexp_desc = Pexp_extension ({txt = "sqlcheck"; loc}, pstr)} ->
+        call_sqlcheck loc pstr
+    (* Delegate to the default mapper *)
+    | x -> default_mapper.expr mapper x;
+})
+
+let () =
+  Random.self_init ();
+  Ast_mapper.register "sqlexpr" new_mapper

--- a/src/ppx/sqlexpr_parser.ml
+++ b/src/ppx/sqlexpr_parser.ml
@@ -1,0 +1,92 @@
+type typ = Int | Int32 | Int64 | Float | Text | Blob | Bool | Any
+type input = typ * bool
+type output = string * typ * bool
+
+let str2typ = function
+  | "d" -> Int
+  | "l" -> Int32
+  | "L" -> Int64
+  | "f" -> Float
+  | "s" -> Text
+  | "S" -> Blob
+  | "b" -> Bool
+  | "a" -> Any
+  | _ -> failwith "Invalid type"
+
+let typ2str = function
+  | Int -> "int"
+  | Int32 -> "int32"
+  | Int64 -> "int64"
+  | Float -> "float"
+  | Text -> "text"
+  | Blob -> "blob"
+  | Bool -> "bool"
+  | Any -> "any"
+
+let in_type2str ((typ, optional) : input) =
+  let typ = typ2str typ in
+  if optional then "maybe_" ^ typ else typ
+
+let out_type2str ((_, typ, optional) : output) =
+  in_type2str (typ, optional)
+
+let parse str =
+  (* grievous hack to escape everything within quotes *)
+  (* what about ignoring \' or \" ?       " *)
+  (* manually escape "" because {| ... |} notation breaks syntax highlighting *)
+  let escrgx = Re_pcre.regexp "('[^']*')|(\"[^\"]*\")" in
+  let esc_list = ref [] in
+  let esc_str = "<SQLEXPR_PRESERVED>" in
+  let esc_subst substrings =
+    let mtch = Re.get substrings 0 in
+    esc_list := mtch :: !esc_list;
+    esc_str in
+
+  let escaped = Re.replace ~f:esc_subst escrgx str in
+  esc_list := List.rev !esc_list;
+
+  (* logic to extract inputs and outputs *)
+  let inrgx = Re_pcre.regexp {|%([dlLfsSba])(\?)?|} in
+  let outrgx = Re_pcre.regexp {|@([dlLfsSba])(\?)?\{((\w|\.)+)\}|} in
+  let getin (acc : input list) s =
+    let groups = Re.get_all s in
+    let typ = Array.get groups 1 |> str2typ in
+    let optional = "?" = Array.get groups 2 in
+    let res = typ, optional in
+    res::acc in
+  let getout (acc : output list) s =
+    let groups = Re.get_all s in
+    let typ = Array.get groups 1 |> str2typ in
+    let optional = "?" = Array.get groups 2 in
+    let name = Array.get groups 3 |> String.trim in
+    let res = name, typ, optional in
+    res::acc in
+
+  (* execute extractions *)
+  let ins = Re.all inrgx escaped |> List.fold_left getin [] |> List.rev in
+  let outs = Re.all outrgx escaped |> List.fold_left getout [] |> List.rev in
+
+  (* replace input and output params with regular SQL *)
+  let in_subst substrs = "?" in
+
+  let rep_count_out = ref 0 in
+  let out_subst substrs =
+    let (name, _,_) = List.nth outs !rep_count_out in
+    incr rep_count_out;
+    name in
+
+  (* now restore the escaped strings *)
+  let rep_esc_count = ref 0 in
+  let unesc_subst substrs =
+    let restore = List.nth !esc_list !rep_esc_count in
+    incr rep_esc_count;
+    restore in
+
+  (* generate final sql *)
+  let sql =
+       Re.replace ~f:out_subst outrgx escaped
+    |> Re.replace ~f:in_subst inrgx
+    |> Re.replace ~f:unesc_subst (Re_pcre.regexp esc_str) in
+
+  (* final return *)
+  (sql, ins, outs)

--- a/tests/t_ppx_parse.ml
+++ b/tests/t_ppx_parse.ml
@@ -1,0 +1,70 @@
+open OUnit
+
+module Sqlexpr = Sqlexpr_sqlite.Make(Sqlexpr_concurrency.Id)
+module S = Sqlexpr
+
+let ae = assert_equal ~printer:(fun x -> x)
+
+let pqi (d : ('a , 'b) S.statement) = d.S.sql_statement
+let pq (d : ('a, 'b, 'c) S.expression) = pqi d.S.statement
+
+let test_sql _ =
+
+  let s = pqi [%sql "insert into values(%s{foo}, %s{bar})"] in
+  ae "insert into values(?{foo}, ?{bar})" s;
+
+  let s = pq [%sql "@d{kilroy} was @s{here}"] in
+  ae "kilroy was here" s;
+
+  (* dots in column names should be okay *)
+  let s = pq [%sql "select @d{t1.id}, @s{t1.label} from table as t1 ..."] in
+  ae "select t1.id, t1.label from table as t1 ..." s;
+
+  (* verifies the order of regex substitution. output substitution pass runs
+   * before the input pass to avoid injecting valid sqlexpr metacharacter '?'.
+   * For example, given the following string, running the input pass first would
+   * result in a valid sqlexpr string, leading to an incorrect substitiion in
+   * the output pass. never mind that immediately adjacent inputs+outputs in
+   *  valid SQL are extremely unlikely... *)
+  let s = pqi [%sql "@s%d{abc}"] in
+  ae "@s?{abc}" s;
+
+  (* test invalid expressions and adjacencies *)
+  let s = pq [%sql "@s@s %d@s{abc}%d@s%d@s%d{def}%d{ghi}@s"] in
+  ae "@s@s ?abc?@s?@s?{def}?{ghi}@s" s;
+
+  (* column name is not alphanumeric so leave as-is (only dots are allowed) *)
+  (* also check that whitespace is preserved *)
+  let s = pqi [%sql "@s{:kilroy}     @@was %@{here}"] in
+  ae "@s{:kilroy}     @@was %@{here}" s;
+
+  let s = pqi [%sql "excellent"] in
+  ae "excellent" s
+
+
+let test_quotes _ =
+
+  (* single quotes *)
+  let s = pq [%sql "strftime('%s-%d', %s-%d @s{abc}%d{def} '@s{abc}%d{def}')"] in
+  ae "strftime('%s-%d', ?-? abc?{def} '@s{abc}%d{def}')" s;
+
+  (* double quotes *)
+  let s = pq [%sql{|strftime("%s-%d", %s-%d @s{abc}%d{def} "@s{abc}%d{def}")|}] in
+  ae {|strftime("%s-%d", ?-? abc?{def} "@s{abc}%d{def}")|} s;
+
+  (* mixed quotes and nested quotes *)
+  let s = pq [%sql {|@s{abc}"@s{def}"'@d{ghi}''%f'%f"%S"%S "'@s{jkl}%d'" '"%d'"|}] in
+  ae {|abc"@s{def}"'@d{ghi}''%f'?"%S"? "'@s{jkl}%d'" '"%d'"|} s;
+
+  (* more nested and unbalanced quotes *)
+  let s = pqi [%sql {|"'%d'" %d '"%d"' "'%d"'|}] in
+  ae {|"'%d'" ? '"%d"' "'%d"'|} s
+
+
+let tests =
+  "ppx_tests">::: [
+    "test_sql">::test_sql;
+    "test_quotes">::test_quotes;
+  ]
+
+let _ = run_test_tt_main tests

--- a/tests/t_ppx_sqlexpr.ml
+++ b/tests/t_ppx_sqlexpr.ml
@@ -1,0 +1,424 @@
+
+open Printf
+open OUnit
+open Lwt
+
+let (>>=) = Lwt.bind
+
+let aeq_int = assert_equal ~printer:(sprintf "%d")
+let aeq_str = assert_equal ~printer:(sprintf "%S")
+let aeq_float = assert_equal ~printer:(sprintf "%f")
+let aeq_int32 = assert_equal ~printer:(sprintf "%ld")
+let aeq_int64 = assert_equal ~printer:(sprintf "%Ld")
+let aeq_bool = assert_equal ~printer:string_of_bool
+
+let aeq_list ~printer =
+  assert_equal
+    ~printer:(fun l -> "[ " ^ String.concat "; " (List.map printer l) ^ " ]")
+
+module Test
+  (Lwt : sig
+     include Sqlexpr_concurrency.THREAD
+     val iter : ('a -> unit t) -> 'a list -> unit t
+     val run : 'a t -> 'a
+   end)
+  (Sqlexpr : sig
+     include Sqlexpr_sqlite.S with type 'a result = 'a Lwt.t
+   end) =
+struct
+  open Lwt
+  module S = Sqlexpr
+
+  let (>|=) f g = bind f (fun x -> return (g x))
+
+  (* schema changes to :memory: db made by a Sqlexpr_sqlite_lwt worker are not
+   * seen by the others, so allow to use a file by doing ~in_mem:false *)
+  let with_db ?(in_mem = true) f x =
+    let file =
+      if in_mem then ":memory:" else Filename.temp_file "t_sqlexpr_sqlite_" "" in
+    let db = S.open_db file in
+    let%lwt () = try%lwt
+        f db x
+    with _ -> return () in
+    S.close_db db;
+    if not in_mem then Sys.remove file;
+    return ()
+
+  let test_execute () =
+    with_db
+      (fun db () ->
+        S.execute db [%sql "CREATE TABLE foo(id INTEGER PRIMARY KEY)"] >>= fun () ->
+        S.execute db [%sqlc "CREATE TABLE bar(id INTEGER PRIMARY KEY)"] >>= fun ()  ->
+        return ())
+      ()
+
+  let insert_d db l =
+    S.execute db [%sql "CREATE TABLE foo(id INTEGER PRIMARY KEY, v INTEGER)"] >>= fun () ->
+    iter (S.execute db [%sql "INSERT INTO foo(v) VALUES(%d)"]) l
+
+  let insert_l db l =
+    S.execute db [%sql "CREATE TABLE foo(id INTEGER PRIMARY KEY, v INTEGER)"] >>= fun () ->
+    iter (S.execute db [%sql "INSERT INTO foo(v) VALUES(%l)"]) l
+
+  let insert_L db l =
+    S.execute db [%sql "CREATE TABLE foo(id INTEGER PRIMARY KEY, v INTEGER)"] >>= fun () ->
+    iter (S.execute db [%sql "INSERT INTO foo(v) VALUES(%L)"]) l
+
+  let insert_f db l =
+    S.execute db [%sql "CREATE TABLE foo(id INTEGER PRIMARY KEY, v FLOAT)"] >>= fun () ->
+    iter (S.execute db [%sql "INSERT INTO foo(v) VALUES(%f)"]) l
+
+  let insert_s db l =
+    S.execute db [%sql "CREATE TABLE foo(id INTEGER PRIMARY KEY, v TEXT)"] >>= fun () ->
+    iter (S.execute db [sql "INSERT INTO foo(v) VALUES(%s)"]) l
+
+  let insert_S db l =
+    S.execute db [%sql "CREATE TABLE foo(id INTEGER PRIMARY KEY, v BLOB)"] >>= fun () ->
+    iter (S.execute db [%sql "INSERT INTO foo(v) VALUES(%S)"]) l
+
+  let insert_b db l =
+    S.execute db [%sql "CREATE TABLE foo(id INTEGER PRIMARY KEY, v BOOLEAN)"] >>= fun () ->
+    iter (S.execute db [%sql "INSERT INTO foo(v) VALUES(%b)"]) l
+
+  let test_directive_d () = with_db insert_d [1]
+  let test_directive_l () = with_db insert_l [1l]
+  let test_directive_L () = with_db insert_L [1L]
+  let test_directive_f () = with_db insert_f [3.14]
+  let test_directive_s () = with_db insert_s ["foo"]
+  let test_directive_S () = with_db insert_S ["blob"]
+  let test_directive_b () = with_db insert_b [true]
+
+  let test_oexpr fmt insert expr l () =
+    with_db
+      (fun db () ->
+         let n = ref 1 in
+           insert db l >>= fun () ->
+           let l = List.map (fun x -> let i = !n in incr n; (i, x)) l in
+           let%lwt l' = S.select db expr in
+           let l' = List.sort compare l' in
+             aeq_list ~printer:(fun (id, x) -> sprintf ("(%d, " ^^ fmt ^^ ")") id x)
+               l l';
+             return ())
+      ()
+
+  let test_nullable_oexpr fmt insert expr l () =
+    with_db
+      (fun db () ->
+         let n = ref 1 in
+           insert db l >>= fun () ->
+           let l = List.map (fun x -> let i = !n in incr n; (i, Some x)) l in
+           let%lwt l' = S.select db expr in
+           let l' = List.sort compare l' in
+             aeq_list
+               ~printer:(fun (id, x) -> match x with
+                             None -> sprintf "(%d, None)" id
+                           | Some x -> sprintf ("(%d, Some " ^^ fmt ^^ ")") id x)
+               l l';
+             return ())
+      ()
+
+  let test_oexpr_directives =
+    with_db
+      (fun db () ->
+        S.select db [%sql "SELECT @d{%d}"] 42 >|= aeq_list ~printer:(sprintf "%d") [42] >>= fun () ->
+        S.select db [%sql "SELECT @f{%d}"] 42 >|= aeq_list ~printer:(sprintf "%f") [42.] >>= fun () ->
+        S.select db [%sql "SELECT @s{%d}"] 42 >|= aeq_list ~printer:(sprintf "%s") ["42"])
+
+  let (>::) name f = name >:: (fun () -> run (f ()))
+
+  let test_directives =
+    [
+      "%d" >:: test_directive_d;
+      "%l" >:: test_directive_l;
+      "%L" >:: test_directive_L;
+      "%f" >:: test_directive_f;
+      "%s" >:: test_directive_s;
+      "%S" >:: test_directive_S;
+      "%b" >:: test_directive_b;
+    ]
+
+  let test_outputs =
+    let t = test_oexpr in
+    let tn = test_nullable_oexpr in
+      [
+        "%d" >:: t "%d" insert_d [%sql "SELECT @d{id}, @d{v} FROM foo"] [1;-1;3;4];
+        "%l" >:: t "%ld" insert_l [%sql "SELECT @d{id}, @l{v} FROM foo"] [1l;-1l;3l;4l];
+        "%L" >:: t "%Ld" insert_L [%sql "SELECT @d{id}, @L{v} FROM foo"] [1L;-1L;3L;4L];
+        "%f" >:: t "%f" insert_f [%sql "SELECT @d{id}, @f{v} FROM foo"] [1.;-1.; 10.; 1e2];
+        "%s" >:: t "%s" insert_s [%sql "SELECT @d{id}, @s{v} FROM foo"] ["foo"; "bar"; "baz"];
+        "%S" >:: t "%S" insert_s [%sql "SELECT @d{id}, @S{v} FROM foo"] ["foo"; "bar"; "baz"];
+        "%b" >:: t "%b" insert_b [%sql "SELECT @d{id}, @b{v} FROM foo"] [true; false];
+
+        (* nullable *)
+        "%d" >:: tn "%d" insert_d [%sql "SELECT @d{id}, @d?{v} FROM foo"] [1;-1;3;4];
+        "%l" >:: tn "%ld" insert_l [%sql "SELECT @d{id}, @l?{v} FROM foo"] [1l;-1l;3l;4l];
+        "%L" >:: tn "%Ld" insert_L [%sql "SELECT @d{id}, @L?{v} FROM foo"] [1L;-1L;3L;4L];
+        "%f" >:: tn "%f" insert_f [%sql "SELECT @d{id}, @f?{v} FROM foo"] [1.;-1.; 10.; 1e2];
+        "%s" >:: tn "%s" insert_s [%sql "SELECT @d{id}, @s?{v} FROM foo"] ["foo"; "bar"; "baz"];
+        "%S" >:: tn "%S" insert_s [%sql "SELECT @d{id}, @S?{v} FROM foo"] ["foo"; "bar"; "baz"];
+        "%b" >:: tn "%b" insert_b [%sql "SELECT @d{id}, @b?{v} FROM foo"] [true; false];
+      ]
+
+  exception Cancel
+
+  let test_transaction () =
+    with_db begin fun db () ->
+      let s_of_pair (id, data) = sprintf "(%d, %S)" id data in
+      let get_rows db = S.select db [%sql "SELECT @d{id}, @s{data} FROM foo ORDER BY id"] in
+      let get_one db = S.select_one db [%sql "SELECT @d{id}, @s{data} FROM foo ORDER BY id"] in
+      let get_one' db = S.select_one db [%sqlc "SELECT @d{id}, @s{data} FROM foo ORDER BY id"] in
+      let insert db = S.execute db [%sql "INSERT INTO foo(id, data) VALUES(%d, %s)"] in
+      let aeq = aeq_list ~printer:s_of_pair in
+      let aeq_one = assert_equal ~printer:s_of_pair in
+        S.execute db [%sql "CREATE TABLE foo(id INTEGER NOT NULL, data TEXT NOT NULL)"] >>= fun () ->
+        get_rows db >|= aeq ~msg:"Init" [] >>= fun () ->
+        S.transaction db
+          (fun db ->
+             get_rows db >|= aeq [] >>= fun () ->
+             insert db 1 "foo" >>= fun () ->
+             get_rows db >|= aeq ~msg:"One insert in TX" [1, "foo"] >>= fun () ->
+             get_one db >|= aeq_one ~msg:"select_one after 1 insert in TX" (1, "foo") >>= fun () ->
+             get_one' db >|= aeq_one ~msg:"select_one (cached) after 1 insert in TX"
+                               (1, "foo") >>= fun () ->
+             try%lwt
+               S.transaction db
+                 (fun db ->
+                    insert db 2 "bar" >>= fun () ->
+                    get_rows db >|= aeq ~msg:"Insert in nested TX" [1, "foo"; 2, "bar";] >>= fun () ->
+                    fail Cancel)
+             with Cancel ->
+               get_rows db >|= aeq ~msg:"After nested TX is canceled" [1, "foo"]) >>= fun () ->
+        get_rows db >|= aeq [1, "foo"];
+    end ()
+
+  let test_retry_begin () =
+
+    let count_rows db =
+      S.select_one db [%sqlc "SELECT @d{COUNT(*)} FROM foo"] in
+
+    let insert v db =
+      (* SELECT acquires a SHARED lock if needed *)
+      let%lwt _ = count_rows db in
+        Lwt.sleep 0.010 >>= fun () ->
+        (* RESERVED lock acquired if needed *)
+        S.insert db [%sqlc "INSERT INTO foo VALUES(%d)"] v in
+
+    let fname = Filename.temp_file "t_sqlexpr_sqlite_excl_retry" "" in
+    let db1   = S.open_db fname in
+    let db2   = S.open_db fname in
+
+      S.execute db1 sqlc"CREATE TABLE foo(id INTEGER PRIMARY KEY)" >>= fun () ->
+      (* these 2 TXs are serialized because they are EXCLUSIVE *)
+      let%lwt _   = S.transaction ~kind:`EXCLUSIVE db1 (insert 1)
+      and _   = S.transaction ~kind:`EXCLUSIVE db2 (insert 2) in
+      let%lwt n   = count_rows db1 in
+        aeq_int ~msg:"number of rows inserted" 2 n;
+        return ()
+
+  let test_fold_and_iter () =
+    with_db begin fun db () ->
+      S.execute db [%sql "CREATE TABLE foo(n INTEGER NOT NULL)"] >>= fun () ->
+      let l = Array.to_list (Array.init 100 (fun n -> 1 + Random.int 100000)) in
+        iter (S.execute db [%sqlc "INSERT INTO foo(n) VALUES(%d)"]) l >>= fun () ->
+        let sum = List.fold_left (+) 0 l in
+        let%lwt count, sum' =
+          S.fold db
+            (fun (count, sum) n -> return (count + 1, sum + n))
+            (0, 0) sqlc"SELECT @d{n} FROM foo"
+        in
+          aeq_int ~msg:"fold: number of elements" (List.length l) count;
+          aeq_int ~msg:"fold: sum of elements" sum sum';
+          let count = ref 0 in
+          let sum' = ref 0 in
+          let%lwt () =
+            S.iter db
+              (fun n -> incr count; sum' := !sum' + n; return ())
+              sqlc"SELECT @d{n} FROM foo"
+          in
+            aeq_int ~msg:"iter: number of elements" (List.length l) !count;
+            aeq_int ~msg:"iter: sum of elements" sum !sum';
+            return ()
+    end ()
+
+  let rec do_test_nested_iter_and_fold db () =
+    nested_iter_and_fold_write db >>= fun () ->
+    nested_iter_and_fold_read db
+
+  and nested_iter_and_fold_write db =
+    S.execute db [%sql "CREATE TABLE foo(n INTEGER NOT NULL)"] >>= fun () ->
+    iter (S.execute db [%sqlc "INSERT INTO foo(n) VALUES(%d)"]) [1; 2; 3]
+
+  and nested_iter_and_fold_read db =
+    let q = Queue.create () in
+    let expected =
+      List.rev [ 1, 3; 1, 2; 1, 1; 2, 3; 2, 2; 2, 1; 3, 3; 3, 2; 3, 1; ] in
+    let inner = [%sqlc "SELECT @d{n} FROM foo ORDER BY n DESC"] in
+    let outer = [%sqlc "SELECT @d{n} FROM foo ORDER BY n ASC"] in
+    let printer (a, b) = sprintf "(%d, %d)" a b in
+    let%lwt () =
+      S.iter db
+        (fun a -> S.iter db (fun b -> Queue.push (a, b) q; return ()) inner)
+        outer
+    in
+      aeq_list ~printer expected (Queue.fold (fun l x -> x :: l) [] q);
+      let%lwt l =
+        S.fold db
+          (fun l a -> S.fold db (fun l b -> return ((a, b) :: l)) l inner)
+          []
+          outer
+      in aeq_list ~printer expected l;
+         return ()
+
+  let test_nested_iter_and_fold () =
+    (* nested iter/folds will spawn multiple Sqlexpr_sqlite_lwt workers, so
+     * cannot use in-mem DB, lest the table not be created in other workers
+     * than the one where it was created *)
+    with_db ~in_mem:false do_test_nested_iter_and_fold ()
+
+  let expect_missing_table tbl f =
+    try%lwt
+      f () >>= fun () ->
+      assert_failure (sprintf "Expected Sqlite3.Error: missing table %s" tbl)
+    with Sqlexpr_sqlite.Error _ -> return ()
+
+  let test_borrow_worker () =
+    with_db begin fun db () ->
+      (* we borrow a worker repeatedly, but since we're doing everything
+       * sequentially we end up using the same one all the time *)
+      S.borrow_worker db
+        (fun db' ->
+           S.borrow_worker db (fun db'' -> do_test_nested_iter_and_fold db'' ()) >>= fun () ->
+           nested_iter_and_fold_read db') >>= fun () ->
+      nested_iter_and_fold_read db
+    end ()
+
+  let maybe_test flag f () =
+    if flag then f () else return ()
+
+  (* let test_borrow_worker has_real_borrow_worker () = *)
+    (* if has_real_borrow_worker then test_borrow_worker () else return () *)
+
+  let all_tests has_real_borrow_worker =
+    [
+      "Directives" >::: test_directives;
+      "Outputs" >::: test_outputs;
+      "Directives in output exprs" >:: test_oexpr_directives;
+      "Transactions" >:: test_transaction;
+      "Auto-retry BEGIN" >:: test_retry_begin;
+      "Fold and iter" >:: test_fold_and_iter;
+      "Nested fold and iter" >:: test_nested_iter_and_fold;
+      "Borrow worker" >:: maybe_test has_real_borrow_worker test_borrow_worker;
+    ]
+end
+
+let test_lwt_recursive_mutex () =
+  let module M = Sqlexpr_concurrency.Lwt in
+  let mv = Lwt_mvar.create () in
+  let m = M.create_recursive_mutex () in
+  let l = ref [] in
+  let push x = l := x :: !l; return () in
+  let%lwt n = M.with_lock m (fun () -> M.with_lock m (fun () -> return 42)) in
+    aeq_int 42 n;
+    let t1 = M.with_lock m (fun () -> push 1 >>= fun () -> Lwt_mvar.take mv >>= fun () -> push 2) in
+    let t2 = M.with_lock m (fun () -> push 3) in
+    let%lwt () = Lwt.join [ t1; t2; Lwt_mvar.put mv () ] in
+      aeq_list ~printer:string_of_int [3; 2; 1] !l;
+      return ()
+
+module type S_LWT = Sqlexpr_sqlite.S with type 'a result = 'a Lwt.t
+
+(* schema changes to :memory: db made by a Sqlexpr_sqlite_lwt worker are not
+ * seen by the others, so allow to use a file by doing ~in_mem:false *)
+let with_db
+      (type a)
+      (module S : S_LWT with type db = a)
+      ?(in_mem = true) f x =
+  let file =
+    if in_mem then ":memory:" else Filename.temp_file "t_sqlexpr_sqlite_" "" in
+  let db = S.open_db file in
+  let%lwt () = try%lwt
+      f db x
+  with _ -> return () in
+  S.close_db db;
+  if not in_mem then Sys.remove file;
+  return ()
+
+let test_exclusion (type a)
+      ((module S : S_LWT with type db = a) as s) () =
+  let module Sqlexpr = S in
+  with_db s ~in_mem:false begin fun db () ->
+    S.execute db [%sql "CREATE TABLE foo(n INTEGER NOT NULL)"] >>= fun () ->
+
+    let exclusion_between_tx_and_single_stmt () =
+      let t1, u1 = Lwt.wait () in
+      let t2, u2 = Lwt.wait () in
+      let t3, u3 = Lwt.wait () in
+      let th1    = S.transaction db
+                     (fun db ->
+                        t1 >|= Lwt.wakeup u2 >>= fun () ->
+                        Lwt_unix.sleep 0.010 >>= fun () ->
+                        S.select_one db [%sql "SELECT @d{COUNT(*)} FROM foo"] >|=
+                          aeq_int ~msg:"number of rows (single stmt exclusion)" 0)
+      and th2    = begin
+                     t3 >>= fun () ->
+                     S.execute db [%sql "INSERT INTO foo VALUES(1)"]
+                   end
+      and th3    = begin
+                     Lwt.wakeup u1 ();
+                     let%lwt () = t2 in
+                       Lwt.wakeup u3 ();
+                       return ()
+                   end
+      in
+        th1 <&> th2 <&> th3 in
+
+    let exclusion_between_txs () =
+      let inside = ref 0 in
+      let check db =
+        let%lwt () = try%lwt
+          incr inside;
+          if !inside > 1 then
+            assert_failure "More than one TX in critical region at a time";
+
+          Lwt_unix.sleep 0.005
+        with _ -> return () in
+        decr inside;
+        return ()
+      in
+        Lwt.join (Sqlexpr_utils.List.init 1 (fun _ -> S.transaction db check))
+    in
+      exclusion_between_txs () >>= fun () ->
+      exclusion_between_tx_and_single_stmt ()
+  end ()
+
+module IdConc =
+struct
+  include Sqlexpr_concurrency.Id
+  let iter = List.iter
+  let run x = x
+end
+
+module LwtConc =
+struct
+  include Sqlexpr_concurrency.Lwt
+  let run x = Lwt_unix.run (Lwt.pick [x; Lwt_unix.timeout 1.0])
+  let iter = Lwt_list.iter_s
+end
+
+let lwt_run f () = LwtConc.run (f ())
+
+let all_tests =
+  [
+    "Sqlexpr_concurrency.Lwt.with_lock" >:: lwt_run test_lwt_recursive_mutex;
+    (let module M = Test(IdConc)(Sqlexpr_sqlite.Make(IdConc)) in
+      "Sqlexpr_sqlite.Make(Sqlexpr_concurrency.Id)" >::: M.all_tests false);
+    (let module M = Test(LwtConc)(Sqlexpr_sqlite.Make(LwtConc)) in
+      "Sqlexpr_sqlite.Make(LwtConcurrency)" >::: M.all_tests false);
+    (let module M = Test(LwtConc)(Sqlexpr_sqlite_lwt) in
+      "Sqlexpr_sqlite_lwt" >::: M.all_tests true);
+    "Sqlexpr_sqlite.Make(LwtConcurrency) exclusion" >::
+      lwt_run (test_exclusion (module Sqlexpr_sqlite.Make(LwtConc)));
+  ]
+
+let _ =
+  run_test_tt_main ("All" >::: all_tests)


### PR DESCRIPTION
Also added some tests for the format-string parser, although the file is not in oasis yet.

The main test suite `t_sqlexpr_sqlite.ml` has also been converted to ppx, however it doesn't currently compile due to this strange type error:

    josh@vesper:~/ocaml/ocaml-sqlexpr$ ocamlfind ocamlc -package sqlexpr.ppx,lwt.ppx,oUnit -thread -linkpkg -ppxopt lwt.ppx,-no-debug tests/t_ppx_sqlexpr.ml
    File "tests/t_ppx_sqlexpr.ml", line 50, characters 8-70:
    Error: This expression has type unit S.result = unit Lwt/1063.t
       but an expression was expected of type 'a Lwt/0.t

As far as I can tell, this is due to the wizardry in the `Test` module that redefines lwt and sqlexpr. Not sure how to fix this.

Note that because lwt is redefined, we need to disable lwt debug due to lwt's syntax extensions calling some lwt-specific functions (backtrace_catch and friends), which don't exist in the redefined signature.