### PR TITLE
WIP: hoisting

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -62,9 +62,11 @@ Library "ppx"
 Executable "ppx_sqlexpr"
   Path:             src/ppx/
   MainIs:           ppx_sqlexpr.ml
-  BuildDepends:     unix, re.pcre, compiler-libs.common, ppx_tools.metaquot
+  BuildDepends:     unix, re.pcre, compiler-libs.common, ppx_tools.metaquot, ppx_core, ppx_driver
   CompiledObject:   best
   Install:          true
+  ByteOpt:          -predicates ppx_driver
+  NativeOpt:        -predicates ppx_driver
 
 Executable "example"
   Path:             tests/

--- a/_tags
+++ b/_tags
@@ -1,5 +1,5 @@
 # OASIS_START
-# DO NOT EDIT (digest: 8c33eb34542ae662c8d9b52b2978ec0d)
+# DO NOT EDIT (digest: f5905681661b090fb1b90f7dc5c9e678)
 # Ignore VCS directories, you can use the same kind of rule outside
 # OASIS_START/STOP if you want to exclude directories that contains
 # useless stuff for the build process
@@ -32,11 +32,19 @@ true: annot, bin_annot
 # Library ppx
 "src/ppx/ppx.cmxs": use_ppx
 # Executable ppx_sqlexpr
+<src/ppx/ppx_sqlexpr.{native,byte}>: oasis_executable_ppx_sqlexpr_byte
+<src/ppx/*.ml{,i,y}>: oasis_executable_ppx_sqlexpr_byte
+<src/ppx/ppx_sqlexpr.{native,byte}>: oasis_executable_ppx_sqlexpr_native
+<src/ppx/*.ml{,i,y}>: oasis_executable_ppx_sqlexpr_native
 <src/ppx/ppx_sqlexpr.{native,byte}>: pkg_compiler-libs.common
+<src/ppx/ppx_sqlexpr.{native,byte}>: pkg_ppx_core
+<src/ppx/ppx_sqlexpr.{native,byte}>: pkg_ppx_driver
 <src/ppx/ppx_sqlexpr.{native,byte}>: pkg_ppx_tools.metaquot
 <src/ppx/ppx_sqlexpr.{native,byte}>: pkg_re.pcre
 <src/ppx/ppx_sqlexpr.{native,byte}>: pkg_unix
 <src/ppx/*.ml{,i,y}>: pkg_compiler-libs.common
+<src/ppx/*.ml{,i,y}>: pkg_ppx_core
+<src/ppx/*.ml{,i,y}>: pkg_ppx_driver
 <src/ppx/*.ml{,i,y}>: pkg_ppx_tools.metaquot
 <src/ppx/*.ml{,i,y}>: pkg_re.pcre
 <src/ppx/*.ml{,i,y}>: pkg_unix

--- a/opam
+++ b/opam
@@ -14,6 +14,8 @@ build-doc: [["ocaml" "setup.ml" "-doc"]]
 remove: [["ocamlfind" "remove" "sqlexpr"]]
 depends: [
   "ppx_tools"
+  "ppx_core"
+  "ppx_driver"
   "estring"
   "csv"
   "lwt" {>= "2.2.0"}


### PR DESCRIPTION
Not really intended for merging, just a preview of work so far -- I'm still learning ppx too. Feedback welcome.

Firstly, this adds an extension on `Ppx_core` for AST folding. The setup for that is quite complex (thanks @Drup for help with this and all my other ppx questions...). The biggest issue is that I think using `Ppx_core` introduces a transitive dependency on OCaml >= 4.02.3, which is probably undesirable for `sqlexpr`. I can either try reworking the opam/oasis files to compile ppx only conditionally (hopefully that's possible?), or implement a fold using OCaml's `Ast_iterator`.

The ppx tests for sqlexpr all pass, but this doesn't yet hoist everything that `pa_estring` does: handling for `Pstr_eval` and `Pstr_class` are missing. The latter simply hasn't been done yet, and the former [1] leads to some very strange interactions with Lwt bindings [2].  (Probably a bug on my end, but I haven't figured it out yet...)

Also there are no tests explicitly for hosting, but the regular test suite seems to stress the mechanism pretty well, I think. Probably should add some more tests once `Pstr_eval` and `Pstr_class` get added in.

Finally, a thought I had while implementing this: it might be more idiomatic to use an annotation alongside the `[%sql ...]` declaration, eg `[@cached]` or similar, rather than defining `[%sqlc ...]` as a separate extension. Since the work for `[%sqlc ...]` has been done already, probably doesn't matter too much.

[1]  https://github.com/j0sh/ocaml-sqlexpr/commit/e828cff3c0889790955a0b7c046bf11ec954ff17
[2] https://gist.github.com/j0sh/434844532f67e87ffb60#file-broken-ml-L31-L42