### PR TITLE
Convert internal code to use ppx

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -6,7 +6,7 @@ B _build/src/syntax
 B _build/tests
 B +threads
 PKG lwt
-PKG lwt.syntax
+PKG lwt.ppx
 PKG sqlite3
 PKG unix
 PKG csv

--- a/INSTALL
+++ b/INSTALL
@@ -18,10 +18,8 @@ Dependencies
 In order to compile this package, you will need:
 * ocaml
 * findlib
-* camlp4
 * cppo
 * csv
-* estring
 * lwt (>= 2.2.0)
 * lwt.syntax
 * lwt.unix
@@ -31,18 +29,25 @@ In order to compile this package, you will need:
 * threads
 * unix
 
+Dependencies
+============
+
+The optional dependencies allow building of the Camlp4 syntax extension.
+* camlp4
+* estring
+
 Installing
 ==========
 
 1. Uncompress source directory and got to the root of the package
-2. Run 'ocaml setup.ml -configure'
+2. Run 'ocaml setup.ml -configure [--disable-camlp4]'
 3. Run 'ocaml setup.ml -build'
 4. Run 'ocaml setup.ml -install'
 
 Alternatively:
 
 1. Uncompress source directory and got to the root of the package
-2. Run './configure"
+2. Run './configure [--disable-camlp4]"
 3. Run 'make"
 4. Run 'make install"
 

--- a/OMakefile
+++ b/OMakefile
@@ -5,13 +5,11 @@ BYTE_ENABLED   = true
 OCAMLPACKS[] =
     csv
     sqlite3
-    estring
     lwt
+    lwt.ppx
     lwt.unix
-    lwt.syntax
     threads
 
-OCAMLFINDFLAGS = -syntax camlp4o
 OCAMLFLAGS     = -thread -bin-annot -g -w +a-4-6-9-27..29-32..99 -warn-error -a
 
 OCAMLDEP_MODULES_ENABLED = false

--- a/README.md
+++ b/README.md
@@ -37,10 +37,8 @@ See also the example file `example.ml`.
 
 ## Dependencies
 
-* camlp4
 * cppo
 * csv
-* estring
 * lwt (>= 2.2.0)
 * lwt.syntax
 * lwt.unix
@@ -49,6 +47,13 @@ See also the example file `example.ml`.
 * sqlite3
 * threads
 * unix
+
+## Optional Dependencies
+
+* camlp4
+* estring
+
+The optional dependencies allow building of the Camlp4 syntax extension.
 
 ## Camlp4 syntax extension
 

--- a/_oasis
+++ b/_oasis
@@ -8,7 +8,7 @@ License:     LGPL-2.1 with OCaml linking exception
 Plugins:     DevFiles (0.3), META (0.3)
 BuildTools:  ocamlbuild
 Homepage:    http://github.com/mfp/ocaml-sqlexpr
-OCamlVersion: >= 4.01
+OCamlVersion: >= 4.02
 AlphaFeatures: ocamlbuild_more_args
 XOCamlbuildPluginTags: package(cppo_ocamlbuild)
 Description:
@@ -33,6 +33,10 @@ SourceRepository github
   Type:     git
   Location: git://github.com/mfp/ocaml-sqlexpr.git
 
+Flag camlp4
+  Description:      Build sqlexpr with camlp4 syntax extensions
+  Default:          true
+
 Library sqlexpr
   Path:             src
   BuildTools:       ocamlbuild
@@ -49,6 +53,7 @@ Library "sqlexpr_syntax"
   FindlibName:      syntax
   FindlibParent:    sqlexpr
   Modules:          Pa_sql
+  Build$:           flag(camlp4)
   BuildDepends:     camlp4.lib, camlp4.quotations.r, estring
   XMETADescription: Syntax extension for SQL statements/expressions
   XMETAType:        syntax

--- a/_oasis
+++ b/_oasis
@@ -40,7 +40,7 @@ Library sqlexpr
                     Sqlexpr_sqlite,
                     Sqlexpr_sqlite_lwt,
                     Sqlexpr_utils
-  BuildDepends:     csv, sqlite3, estring, lwt (>= 2.2.0), lwt.syntax, lwt.unix,
+  BuildDepends:     csv, sqlite3, lwt (>= 2.2.0), lwt.ppx, lwt.unix,
                     unix, threads
   XMETADescription: SQLite database access.
 

--- a/_tags
+++ b/_tags
@@ -1,5 +1,5 @@
 # OASIS_START
-# DO NOT EDIT (digest: 8c33eb34542ae662c8d9b52b2978ec0d)
+# DO NOT EDIT (digest: d89a93f25aa57937466d3bcf30b0954f)
 # Ignore VCS directories, you can use the same kind of rule outside
 # OASIS_START/STOP if you want to exclude directories that contains
 # useless stuff for the build process
@@ -16,53 +16,52 @@ true: annot, bin_annot
 "_darcs": not_hygienic
 # Library sqlexpr
 "src/sqlexpr.cmxs": use_sqlexpr
-<src/*.ml{,i,y}>: pkg_csv
-<src/*.ml{,i,y}>: pkg_estring
-<src/*.ml{,i,y}>: pkg_lwt
-<src/*.ml{,i,y}>: pkg_lwt.syntax
-<src/*.ml{,i,y}>: pkg_lwt.unix
-<src/*.ml{,i,y}>: pkg_sqlite3
-<src/*.ml{,i,y}>: pkg_threads
-<src/*.ml{,i,y}>: pkg_unix
+<src/*.ml{,i,y}>: package(csv)
+<src/*.ml{,i,y}>: package(lwt)
+<src/*.ml{,i,y}>: package(lwt.ppx)
+<src/*.ml{,i,y}>: package(lwt.unix)
+<src/*.ml{,i,y}>: package(sqlite3)
+<src/*.ml{,i,y}>: package(threads)
+<src/*.ml{,i,y}>: package(unix)
 # Library sqlexpr_syntax
 "src/syntax/sqlexpr_syntax.cmxs": use_sqlexpr_syntax
-<src/syntax/*.ml{,i,y}>: pkg_camlp4.lib
-<src/syntax/*.ml{,i,y}>: pkg_camlp4.quotations.r
-<src/syntax/*.ml{,i,y}>: pkg_estring
+<src/syntax/*.ml{,i,y}>: package(camlp4.lib)
+<src/syntax/*.ml{,i,y}>: package(camlp4.quotations.r)
+<src/syntax/*.ml{,i,y}>: package(estring)
 # Library ppx
 "src/ppx/ppx.cmxs": use_ppx
 # Executable ppx_sqlexpr
-<src/ppx/ppx_sqlexpr.{native,byte}>: pkg_compiler-libs.common
-<src/ppx/ppx_sqlexpr.{native,byte}>: pkg_ppx_tools.metaquot
-<src/ppx/ppx_sqlexpr.{native,byte}>: pkg_re.pcre
-<src/ppx/ppx_sqlexpr.{native,byte}>: pkg_unix
-<src/ppx/*.ml{,i,y}>: pkg_compiler-libs.common
-<src/ppx/*.ml{,i,y}>: pkg_ppx_tools.metaquot
-<src/ppx/*.ml{,i,y}>: pkg_re.pcre
-<src/ppx/*.ml{,i,y}>: pkg_unix
+<src/ppx/ppx_sqlexpr.{native,byte}>: package(compiler-libs.common)
+<src/ppx/ppx_sqlexpr.{native,byte}>: package(ppx_tools.metaquot)
+<src/ppx/ppx_sqlexpr.{native,byte}>: package(re.pcre)
+<src/ppx/ppx_sqlexpr.{native,byte}>: package(unix)
+<src/ppx/*.ml{,i,y}>: package(compiler-libs.common)
+<src/ppx/*.ml{,i,y}>: package(ppx_tools.metaquot)
+<src/ppx/*.ml{,i,y}>: package(re.pcre)
+<src/ppx/*.ml{,i,y}>: package(unix)
 # Executable example
-<tests/example.{native,byte}>: pkg_camlp4.lib
-<tests/example.{native,byte}>: pkg_camlp4.quotations.r
-<tests/example.{native,byte}>: pkg_csv
-<tests/example.{native,byte}>: pkg_estring
-<tests/example.{native,byte}>: pkg_lwt
-<tests/example.{native,byte}>: pkg_lwt.syntax
-<tests/example.{native,byte}>: pkg_lwt.unix
-<tests/example.{native,byte}>: pkg_sqlite3
-<tests/example.{native,byte}>: pkg_threads
-<tests/example.{native,byte}>: pkg_unix
+<tests/example.{native,byte}>: package(camlp4.lib)
+<tests/example.{native,byte}>: package(camlp4.quotations.r)
+<tests/example.{native,byte}>: package(csv)
+<tests/example.{native,byte}>: package(estring)
+<tests/example.{native,byte}>: package(lwt)
+<tests/example.{native,byte}>: package(lwt.ppx)
+<tests/example.{native,byte}>: package(lwt.unix)
+<tests/example.{native,byte}>: package(sqlite3)
+<tests/example.{native,byte}>: package(threads)
+<tests/example.{native,byte}>: package(unix)
 <tests/example.{native,byte}>: use_sqlexpr
 <tests/example.{native,byte}>: use_sqlexpr_syntax
-<tests/*.ml{,i,y}>: pkg_camlp4.lib
-<tests/*.ml{,i,y}>: pkg_camlp4.quotations.r
-<tests/*.ml{,i,y}>: pkg_csv
-<tests/*.ml{,i,y}>: pkg_estring
-<tests/*.ml{,i,y}>: pkg_lwt
-<tests/*.ml{,i,y}>: pkg_lwt.syntax
-<tests/*.ml{,i,y}>: pkg_lwt.unix
-<tests/*.ml{,i,y}>: pkg_sqlite3
-<tests/*.ml{,i,y}>: pkg_threads
-<tests/*.ml{,i,y}>: pkg_unix
+<tests/*.ml{,i,y}>: package(camlp4.lib)
+<tests/*.ml{,i,y}>: package(camlp4.quotations.r)
+<tests/*.ml{,i,y}>: package(csv)
+<tests/*.ml{,i,y}>: package(estring)
+<tests/*.ml{,i,y}>: package(lwt)
+<tests/*.ml{,i,y}>: package(lwt.ppx)
+<tests/*.ml{,i,y}>: package(lwt.unix)
+<tests/*.ml{,i,y}>: package(sqlite3)
+<tests/*.ml{,i,y}>: package(threads)
+<tests/*.ml{,i,y}>: package(unix)
 <tests/*.ml{,i,y}>: use_sqlexpr
 <tests/*.ml{,i,y}>: use_sqlexpr_syntax
 # OASIS_STOP

--- a/_tags
+++ b/_tags
@@ -67,6 +67,5 @@ true: annot, bin_annot
 <tests/*.ml{,i,y}>: use_sqlexpr_syntax
 # OASIS_STOP
 <src/*.ml{,i}>: thread
-<src/*.ml{,i}>: syntax(camlp4o)
 <src/syntax/*.ml{,i}>: syntax(camlp4o)
 "src/ppx/ppx_sqlexpr.ml": cppo_V_OCAML

--- a/opam
+++ b/opam
@@ -4,7 +4,7 @@ authors: ["Mauricio Fernandez <mfp@acm.org>"]
 homepage: "http://github.com/mfp/ocaml-sqlexpr"
 license: "LGPL-2.1 with OCaml linking exception"
 build: [
-  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix "--%{estring:enable}%-camlp4"]
   ["ocaml" "setup.ml" "-build"]
 ]
 install:[
@@ -14,14 +14,17 @@ build-doc: [["ocaml" "setup.ml" "-doc"]]
 remove: [["ocamlfind" "remove" "sqlexpr"]]
 depends: [
   "ppx_tools"
-  "estring"
   "csv"
   "lwt" {>= "2.2.0"}
   "ocamlfind"
   ("sqlite3" {>= "2.0.4"} | "sqlite3" {= "2.0.3"})
   "base-unix"
+  "re"
   "ocamlbuild" {build}
   "cppo" {build}
+]
+depopts: [
+  "estring"
 ]
 dev-repo: "https://github.com/mfp/ocaml-sqlexpr.git"
 bug-reports: "https://github.com/mfp/ocaml-sqlexpr/issues"

--- a/opam
+++ b/opam
@@ -28,4 +28,4 @@ depopts: [
 ]
 dev-repo: "https://github.com/mfp/ocaml-sqlexpr.git"
 bug-reports: "https://github.com/mfp/ocaml-sqlexpr/issues"
-available: ocaml-version >= "4.02.0" & ocaml-version < "4.04.0"
+available: ocaml-version >= "4.02.0" & ocaml-version <= "4.04.1"

--- a/src/OMakefile
+++ b/src/OMakefile
@@ -1,12 +1,12 @@
 
 .SUBDIRS: syntax
     unsetenv(OCAMLFIND_TOOLCHAIN)
+    OCAMLFINDFLAGS = -syntax camlp4o
     NATIVE_ENABLED = false
     OCAMLPACKS[] = estring camlp4.quotations
     pa_sql.cmi pa_sql.cmo: pa_sql.ml
 
 .SUBDIRS: ppx
-    OCAMLFINDFLAGS =
     OCAMLPACKS[]   = compiler-libs.common ppx_tools.metaquot re.pcre unix
     OCamlProgram(ppx_sqlexpr, sqlexpr_parser ppx_sqlexpr)
 

--- a/src/sqlexpr_concurrency.ml
+++ b/src/sqlexpr_concurrency.ml
@@ -13,11 +13,17 @@ sig
   type 'a t
   val return : 'a -> 'a t
   val bind : 'a t -> ('a -> 'b t) -> 'b t
+  val try_bind: (unit -> 'a t) -> ('a -> 'b t) -> (exn -> 'b t) -> 'b t
   val fail : exn -> 'a t
   val catch : (unit -> 'a t) -> (exn -> 'a t) -> 'a t
   val finalize : (unit -> 'a t) -> (unit -> unit t) -> 'a t
   val sleep : float -> unit t
   val auto_yield : float -> (unit -> unit t)
+
+  val backtrace_bind: (exn -> exn) -> 'a t -> ('a -> 'b t) -> 'b t
+  val backtrace_catch: (exn -> exn) -> (unit -> 'a t) -> (exn -> 'a t) -> 'a t
+  val backtrace_finalize: (exn -> exn) -> (unit -> 'a t) -> (unit -> unit t) -> 'a t
+  val backtrace_try_bind: (exn -> exn) -> (unit -> 'a t) -> ('a -> 'b t) -> (exn -> 'b t) -> 'b t
 
   type mutex
 
@@ -56,6 +62,32 @@ struct
   let new_key    = Lwt.new_key
   let get        = Lwt.get
   let with_value = Lwt.with_value
+
+  let try_bind f f' catch =
+    try f' (f ())
+    with e -> catch e
+
+  let backtrace_bind g x f =
+    try f x
+    with e -> raise (g e)
+
+  let backtrace_catch g f catch =
+    try f ()
+    with e -> catch (g e)
+
+  let backtrace_finalize g f finally =
+    try
+      let x = f() in
+      finally();
+      x
+    with e -> raise (g e)
+
+  let backtrace_try_bind g f f' catch =
+    try
+      let x = f() in
+      f' x
+    with e ->
+      catch (g e)
 
   let register_finaliser f x =
     (* FIXME: should run finalisers sequentially in separate thread *)

--- a/src/sqlexpr_concurrency.mli
+++ b/src/sqlexpr_concurrency.mli
@@ -16,11 +16,17 @@ sig
   type 'a t
   val return : 'a -> 'a t
   val bind : 'a t -> ('a -> 'b t) -> 'b t
+  val try_bind: (unit -> 'a t) -> ('a -> 'b t) -> (exn -> 'b t) -> 'b t
   val fail : exn -> 'a t
   val catch : (unit -> 'a t) -> (exn -> 'a t) -> 'a t
   val finalize : (unit -> 'a t) -> (unit -> unit t) -> 'a t
   val sleep : float -> unit t
   val auto_yield : float -> unit -> unit t
+
+  val backtrace_bind: (exn -> exn) -> 'a t -> ('a -> 'b t) -> 'b t
+  val backtrace_catch: (exn -> exn) -> (unit -> 'a t) -> (exn -> 'a t) -> 'a t
+  val backtrace_finalize: (exn -> exn) -> (unit -> 'a t) -> (unit -> unit t) -> 'a t
+  val backtrace_try_bind: (exn -> exn) -> (unit -> 'a t) -> ('a -> 'b t) -> (exn -> 'b t) -> 'b t
 
   type mutex
 

--- a/tests/OMakefile
+++ b/tests/OMakefile
@@ -8,8 +8,8 @@ OCAMLINCLUDES += $(ROOT)/src
 OCAML_LIBS[] += $(ROOT)/src/sqlexpr
 
 section
-    OCAMLPACKS[] += oUnit
-    OCAMLFINDFLAGS += -syntax camlp4o -ppopt $(ROOT)/src/syntax/pa_sql.cmo
+    OCAMLPACKS[] = csv estring lwt.syntax lwt.unix oUnit sqlite3 threads
+    OCAMLFINDFLAGS = -syntax camlp4o -ppopt $(ROOT)/src/syntax/pa_sql.cmo
     OCamlProgram(t_sqlexpr_sqlite, t_sqlexpr_sqlite)
     OCamlProgram(bm_sqlexpr_sqlite_lwt, bm_sqlexpr_sqlite_lwt)
     $(addsuffixes .o .cmx .cmi .cmo, bm_sqlexpr_sqlite_lwt t_sqlexpr_sqlite):


### PR DESCRIPTION
Based off https://github.com/c-cube/ocaml-sqlexpr/commit/00bb21065077620a44a79c6658c1b3ab91df57ed, updated for current master. Migrates the internal code to lwt's ppx, no external API changes. This should allow us to make camlp4 an optional dependency (eg, only build the syntax extension if camlp4 is already installed), but not sure how to specify that with oasis.

Couple things to note that are mostly unrelated to this patch:

Not sure how to build with OMakefile (I go the `oasis setup; make` route), but had to manually add this line to myocamlbuild.ml:
`let () = Ocamlbuild_plugin.dispatch (fun hook -> Ocamlbuild_cppo.dispatcher hook)`
Should this be documented, or is there a better way?

After generating setup.ml with oasis 0.4.7 (latest release), myocamlbuild.ml doesn't seem to compile anymore. Something about the Ocamlbuild_cppo module being unbound, but haven't been able to figure out whether its changed behavior or a bona fide bug. Because of that, `oasis setup` should be run with oasis 0.4.6 or earlier for now.
