### PR TITLE
Fix compiler warnings 4 and 27

### DIFF
--- a/src/ppx/ppx_sqlexpr.ml
+++ b/src/ppx/ppx_sqlexpr.ml
@@ -96,7 +96,7 @@ let sqlcheck_sqlite () =
     let ret = ref true in
     List.iter (fun stmt -> match Sqlite3.exec db stmt with
       | Sqlite3.Rc.OK -> ()
-      | rc -> begin
+      | _ -> begin
         ret := false;
         Format.fprintf fmt "Error in init. SQL statement (%s)@ %S@\n"
           (Sqlite3.errmsg db) stmt


### PR DESCRIPTION
This fixes the following warnings on [%sqlcheck "sqlite"]:

Warning 4: this pattern-matching is fragile
Warning 27: unused variable rc

See #34